### PR TITLE
fix fileoutput string parameters

### DIFF
--- a/templates/plugin/fileoutput.toml.erb
+++ b/templates/plugin/fileoutput.toml.erb
@@ -3,9 +3,9 @@
 type = "FileOutput"
 <%= scope.function_template(['heka/plugin/_output.toml.erb']) %>
 path = "<%= @path -%>"
-perm = <%= @perm %>
-folder_perm = <%= @folder_perm %>
+perm = "<%= @perm -%>"
+folder_perm = "<%= @folder_perm -%>"
 flush_interval = <%= @flush_interval %>
 flush_count = <%= @flush_count %>
-flush_operator = <%= @flush_operator %>
+flush_operator = "<%= @flush_operator -%>"
 rotation_interval = <%= @rotation_interval %>


### PR DESCRIPTION
Hi Cristi,

I have fixed some errors in fileoutput.toml.erb plugin.
Heka is raising some errors when you are trying to start it, because string parameters are not enclosed by double quotes .

Error from log:

_2016/02/04 10:16:15 Error reading config: Error decoding config file: Near line 13, key 'fileoutput_to_file.flush_operator': Near line 13: Expected value but found 'A' instead.
_

*_fileoutput_to_file.toml
*__# This file is controlled via puppet.
[fileoutput_to_file]
type = "FileOutput"
message_matcher = "TRUE"
ticker_interval = 300
encoder = "ProtobufEncoder"

path = "/var/log/heka-out.log"
perm = 644
folder_perm = 700
flush_interval = 1000
flush_count = 1
flush_operator = AND
rotation_interval = 0_

Thanks
Bogdan
