### PR TITLE
Minor bug fixes

### DIFF
--- a/templates/heka.systemd.service.erb
+++ b/templates/heka.systemd.service.erb
@@ -9,7 +9,7 @@ Type=simple
 # HUP not implemented in heka yet
 #ExecReload=/bin/kill -HUP $MAINPID
 # http://unix.stackexchange.com/questions/263369
-<% unless [nil, :undefined, :undef, ''].include?(scope['heka::journald_forward_enable']) -%>
+<% unless [false, nil, :undefined, :undef, ''].include?(scope['heka::journald_forward_enable']) -%>
 ExecStart=-/bin/sh -c '/usr/bin/hekad -config=/etc/heka 2>&1 | /usr/bin/forward-journald -tag heka'
 StandardOutput=null
 StandardError=null

--- a/templates/plugin/kafkaoutput.toml.erb
+++ b/templates/plugin/kafkaoutput.toml.erb
@@ -7,7 +7,7 @@ type = "KafkaOutput"
 # specific settings
 <% if @id then -%>id = "<%= @id -%>"
 <% end -%>
-addrs=[ <%= addrs.map {|sub| '"'+sub+'"'}.join(",") -%> ]
+addrs=[ <%= @addrs.map {|sub| '"'+sub+'"'}.join(",") -%> ]
 <% if @metadata_retries then -%>metadata_retries = <%= @metadata_retries %>
 <% end -%>
 <% if @wait_for_election then -%>wait_for_election = <%= @wait_for_election %>


### PR DESCRIPTION
Fixed a bug in systemd. Param journald_forward_enable is defaulted to false. But it is not compared to false in the systemd template. So it is allways "seen" as true.

Fixed a bug in plugin kafkaoutput. When using the kafkaoutput plugin, this error would appear:

`
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Failed to parse template heka/plugin/kafkaoutput.toml.erb:
  Filepath: /etc/puppetlabs/code/environments/puppetdev_fabian/modules/heka/templates/plugin/kafkaoutput.toml.erb
  Line: 10
  Detail: undefined local variable or method 'addrs' for #<Puppet::Parser::TemplateWrapper:0x5a6f7938>
 at /etc/puppetlabs/code/environments/puppetdev_fabian/modules/heka/manifests/outputs/kafkaoutput.pp:164:16 at /etc/puppetlabs/code/environments/puppetdev_fabian/modules/profile/manifests/heka/agent.pp:40 on node puppetdev-fabian02.core.cmc.lan
`

It appears that an @ was missing at parameter addrs.
