### PR TITLE
yo61/logrotate module have been deprecated

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
-    logrotate: "yo61/logrotate"
+    logrotate: "puppet/logrotate"
   symlinks:
     heka: "#{source_dir}"
 

--- a/metadata.json
+++ b/metadata.json
@@ -14,8 +14,8 @@
 			"name": "puppetlabs/stdlib",
 			"version_requirement": ">= 4.0.0 < 5.0.0"
 		},{
-			"name": "yo61/logrotate",
-			"version_requirement": ">= 1.3.0 < 2.0.0"
+			"name": "puppet/logrotate",
+			"version_requirement": ">= 2.0.0 < 3.0.0"
 		}
 	],
 	"requirements": [{


### PR DESCRIPTION
And migrated to VoxPupuli (puppet/logrotate).